### PR TITLE
[release/v1.2] unrc versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version: 'stable'
+        go-version-file: 'go.mod'
     - run: make validate
 
   test:
@@ -38,7 +38,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version: 'stable'
+        go-version-file: 'go.mod'
   
     - run: make test
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,11 +12,11 @@ annotations:
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-compliance
 apiVersion: v1
-appVersion: v1.2.5-rc.1
+appVersion: v1.2.5
 description: The compliance-operator enables running security scans on a kubernetes
   cluster
 icon: https://charts.rancher.io/assets/logos/rancher-compliance.svg
 keywords:
 - security
 name: rancher-compliance
-version: 1.2.5-rc.1
+version: 1.2.5

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,10 +5,10 @@
 image:
   operator:
     repository: rancher/compliance-operator
-    tag: v1.2.5-rc.1
+    tag: v1.2.5
   securityScan:
     repository: rancher/security-scan
-    tag: v0.7.7-rc.1
+    tag: v0.7.7
   sonobuoy:
     repository: rancher/mirrored-sonobuoy-sonobuoy
     tag: v0.57.3

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/rancher/kubernetes-provider-detector v0.1.5
 	github.com/rancher/lasso v0.2.3
-	github.com/rancher/security-scan v0.7.7-rc.1
+	github.com/rancher/security-scan v0.7.7
 	github.com/rancher/wrangler/v3 v3.2.2
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/rancher/kubernetes-provider-detector v0.1.5 h1:hWRAsWuJOemzGjz/XrbTlM
 github.com/rancher/kubernetes-provider-detector v0.1.5/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.2.3 h1:74/z/C/O3ykhyMrRuEgc9kVyYiSoS7kp5BAijlcyXDg=
 github.com/rancher/lasso v0.2.3/go.mod h1:G+KeeOaKRjp+qGp0bV6VbLhYrq1vHbJPbDh40ejg5yE=
-github.com/rancher/security-scan v0.7.7-rc.1 h1:Rzk2mGRrX3nm+YXQGaw+B5JqTHepiyDh2nK8bIQAHpg=
-github.com/rancher/security-scan v0.7.7-rc.1/go.mod h1:yZqomB8MnEipJTfcRR00XQkYphJpaJ/v1omRg6vbNYc=
+github.com/rancher/security-scan v0.7.7 h1:n0BWfZPTAN5N6TRGvMQzV3M8j/Tpa0zcEiL73VzBuTQ=
+github.com/rancher/security-scan v0.7.7/go.mod h1:yZqomB8MnEipJTfcRR00XQkYphJpaJ/v1omRg6vbNYc=
 github.com/rancher/wrangler/v3 v3.2.2 h1:IK1/v8n8gaZSB4izmJhGFXJt38Z8gkbwzl3Lo/e2jQc=
 github.com/rancher/wrangler/v3 v3.2.2/go.mod h1:TA1QuuQxrtn/kmJbBLW/l24IcfHBmSXBa9an3IRlqQQ=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=


### PR DESCRIPTION
update appVersion and version tags to v1.2.5,

updated `go-version: 'stable'`, in `test.yamll` file causing CI failures due to a version mismatch. Using `go-version-file: 'go.mod'` ensures the workflow always uses the exact Go version defined in the project, keeping CI consistent and avoiding build errors.