### PR TITLE
[release/v1.3] unrc versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
-        go-version: 'stable'
+        go-version-file: 'go.mod'
     - run: make validate
 
   test:
@@ -38,7 +38,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
-        go-version: 'stable'
+        go-version-file: 'go.mod'
   
     - run: make test
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,11 +12,11 @@ annotations:
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-compliance
 apiVersion: v1
-appVersion: v1.3.3-rc.1
+appVersion: v1.3.3
 description: The compliance-operator enables running security scans on a kubernetes
   cluster
 icon: https://charts.rancher.io/assets/logos/rancher-compliance.svg
 keywords:
 - security
 name: rancher-compliance
-version: 1.3.3-rc.1
+version: 1.3.3

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,10 +5,10 @@
 image:
   operator:
     repository: rancher/compliance-operator
-    tag: v1.3.3-rc.1
+    tag: v1.3.3
   securityScan:
     repository: rancher/security-scan
-    tag: v0.8.3-rc.1
+    tag: v0.8.3
   sonobuoy:
     repository: rancher/mirrored-sonobuoy-sonobuoy
     tag: v0.57.3

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rancher/kubernetes-provider-detector v0.1.5
 	github.com/rancher/lasso v0.2.5
-	github.com/rancher/security-scan v0.8.3-rc.1
+	github.com/rancher/security-scan v0.8.3
 	github.com/rancher/wrangler/v3 v3.3.1
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/rancher/kubernetes-provider-detector v0.1.5 h1:hWRAsWuJOemzGjz/XrbTlM
 github.com/rancher/kubernetes-provider-detector v0.1.5/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.2.5 h1:K++lWDDdfeN98Ixc1kCfUq0/q6tLjoHN++Np6QntXw0=
 github.com/rancher/lasso v0.2.5/go.mod h1:71rWfv+KkdSmSxZ9Ly5QYhxAu0nEUcaq9N2ByjcHqAM=
-github.com/rancher/security-scan v0.8.3-rc.1 h1:CDO9ceMFJRZIiLfQi3yIB9EawbuNNqMxiIl+OVtEG8s=
-github.com/rancher/security-scan v0.8.3-rc.1/go.mod h1:n4VVFnzJiKRzcNwkwLfrT6oNSQ1hDUM0g+fnmAk1GBo=
+github.com/rancher/security-scan v0.8.3 h1:B1yaAELsthuuiC0VB+c30EUcD18eP9RJRO7WIULHO2I=
+github.com/rancher/security-scan v0.8.3/go.mod h1:n4VVFnzJiKRzcNwkwLfrT6oNSQ1hDUM0g+fnmAk1GBo=
 github.com/rancher/wrangler/v3 v3.3.1 h1:YFqRfhxjuLNudUrvWrn+64wUPZ8pnn2KWbTsha75JLg=
 github.com/rancher/wrangler/v3 v3.3.1/go.mod h1:0D4kZDaOUkP5W2Zfww/75tQwF9w7kaZgzpZG+4XQDAI=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=


### PR DESCRIPTION
update appVersion and version tags to v1.3.3,
updated `go-version: 'stable'`, in `test.yamll` file causing CI failures due to a version mismatch. Using `go-version-file: 'go.mod'` ensures the workflow always uses the exact Go version defined in the project, keeping CI consistent and avoiding build errors.