### PR TITLE
fix: remove placeholder upload lines from %-upload Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,6 @@ upload: clean ## Build and upload artefacts to the GitHub release.
 	GOARCH=$(subst :,/,$*) GOOS=linux \
 		$(MAKE) build
 	
-	@echo "Uploading assets for release $(TAG)..."
-	@gh release upload "$(TAG)" path/to/your/assets/* --clobber
-
+	
 	TAG=$(TAG) \
 		./hack/upload-gh $(subst :,/,$*)


### PR DESCRIPTION
Related PR (main): https://github.com/rancher/compliance-operator/pull/133

`path/to/your/assets/` is a dummy path that  doesn't exist, causing the job to fail immediately with no matches found. This also prevented the actual upload script `./hack/upload-gh` below it from ever being executed. These lines have been removed so the upload target now correctly calls `./hack/upload-gh` to build, preventing jobs from fail