### PR TITLE
[main]aks 1.7 scan update

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,11 +12,11 @@ annotations:
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-compliance
 apiVersion: v1
-appVersion: v1.4.0-rc.4
+appVersion: v1.4.0-rc.5
 description: The compliance-operator enables running security scans on a kubernetes
   cluster
 icon: https://charts.rancher.io/assets/logos/rancher-compliance.svg
 keywords:
 - security
 name: rancher-compliance
-version: 1.4.0-rc.4
+version: 1.4.0-rc.5

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,7 +5,7 @@
 image:
   operator:
     repository: rancher/compliance-operator
-    tag: v1.4.0-rc.4
+    tag: v1.4.0-rc.5
   securityScan:
     repository: rancher/security-scan
     tag: v0.9.0-rc.2

--- a/pkg/securityscan/core/templates/pluginConfig.template
+++ b/pkg/securityscan/core/templates/pluginConfig.template
@@ -62,6 +62,9 @@ data:
       - hostPath:
           path: /var/lib/kubelet
         name: var-kubelet
+      - hostPath:
+          path: /etc/kubernetes/azure.json
+        name: etc-kubernetes
       {{- if .isCustomBenchmark }}
       - configMap:
           defaultMode: 420
@@ -145,6 +148,9 @@ data:
         readOnly: true
       - mountPath: /var/lib/kubelet
         name: var-kubelet
+        readOnly: true
+      - mountPath: /etc/kubernetes/azure.json
+        name: etc-kubernetes
         readOnly: true
       {{- if .isCustomBenchmark }}
       - mountPath: /etc/kbs/custombenchmark/cfg


### PR DESCRIPTION
issue : [issue](https://github.com/rancher/rancher/issues/54095)
Fix for AKS 1.7 scan profile 3.1.3 test fail 
( /etc/kubernetes/azure.json, the file could not be read during the compliance check.
Adding the appropriate hostPath and mountPath allowed the scan pod to mount that directory and read the file for the check.
)