### PR TITLE
[release/v1.5] xccdf format optional metadata for stig and other profiles

### DIFF
--- a/hack/e2e
+++ b/hack/e2e
@@ -109,7 +109,7 @@ do
     
     if [ "${passed}" -gt "0" ]; then
       echo "> compliance-operator worked successfully"
-      
+
       ${KUBECTL} get ClusterScan -o yaml
       ${KUBECTL} get ClusterScanReport -o yaml -A || true
 

--- a/pkg/securityscan/core/templates/pluginConfig.template
+++ b/pkg/securityscan/core/templates/pluginConfig.template
@@ -70,7 +70,7 @@ data:
           defaultMode: 420
           items:
           {{- range $key, $value := .customBenchmarkConfigMapData }}
-          {{- if eq $key "config.yaml"}}
+          {{- if or (eq $key "config.yaml") (eq $key "metadata.yaml") }}
           - key: {{ $key }}
             path: {{ $key }}
           {{- else}}

--- a/pkg/securityscan/job/job.go
+++ b/pkg/securityscan/job/job.go
@@ -287,7 +287,7 @@ func New(clusterscan *operatorapiv1.ClusterScan, clusterscanprofile *operatorapi
 			},
 		}
 		for key := range customcm.Data {
-			if key == "config.yaml" {
+			if key == "config.yaml" || key == "metadata.yaml" {
 				customVol.VolumeSource.ConfigMap.Items = append(customVol.VolumeSource.ConfigMap.Items, corev1.KeyToPath{Key: key, Path: key})
 			} else {
 				customVol.VolumeSource.ConfigMap.Items = append(customVol.VolumeSource.ConfigMap.Items, corev1.KeyToPath{Key: key, Path: clusterscanbenchmark.Name + "/" + key})


### PR DESCRIPTION
backport Merge pull request #312 
Issue: https://github.com/rancher/compliance-operator/issues/319
Jira: SURE-11487

This PR allows the setting of xccdf format for the output of compliance scans, as an alternative to csv. This allows for better integration with compliance management tools such as STIG Manager (https://github.com/nuwcdivnpt/stig-manager) which are commonly used for continuous management of compliance posture across environments. 

On the dashboard (https://github.com/rancher/dashboard/pull/17629) a new download report button is implemented for xccdf, which will download a zip of full compliance report per node in the target cluster. This is in line with the required compliance reporting by security assessors. 

These changes are now format-agnostic, any format (STIG, CIS, etc) can optionally have metadata in their configmap under the 'metadata.yaml' field. 

### Testing/Repro Steps

1. Build updated compliance operator image (https://github.com/rancher/compliance-operator/pull/312).

```bash
docker build --platform linux/amd64 -f package/Dockerfile -t <private-registry>/rancher/compliance-operator:dev
```
```bash
docker push <private-registry>/rancher/compliance-operator:dev
```

2. Ensure compliance operator chart is installed (via Rancher Charts).

3. Edit the deployment to use dev image with pull policy always.

```bash
kubectl edit deployment compliance-operator -n compliance-operator-system
```

```yaml
spec:
  template:
    spec:
      containers:
      - name: compliance-operator
      - image: <private-registry>/rancher/compliance-operator:dev
      - imagePullPolicy: Always
 ```

4. Apply updated compliance operator CRDs.

```bash
kubectl apply -f crds/clusterscan.yaml
kubectl apply -f crds/clusterscanbenchmark.yaml
kubectl apply -f crds/clusterscanreport.yaml
```

5. Build the dashboard locally, setting the API to the cluster you just configured. (PR: https://github.com/rancher/dashboard/pull/17629) 

```bash
API=https://rancher.local npx run dev
```

6. In the UI, run a compliance scan. Once complete, click download report (xccdf) and observe a zip file with .xml reports for each node in the cluster. 
