### PR TITLE
[release/v1.5] Add image pull secret support

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,11 +12,11 @@ annotations:
   catalog.cattle.io/type: cluster-tool
   catalog.cattle.io/ui-component: rancher-compliance
 apiVersion: v1
-appVersion: v1.5.0-rc.3
+appVersion: v1.5.0-rc.4
 description: The compliance-operator enables running security scans on a kubernetes
   cluster
 icon: https://charts.rancher.io/assets/logos/rancher-compliance.svg
 keywords:
 - security
 name: rancher-compliance
-version: 1.5.0-rc.3
+version: 1.5.0-rc.4

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -44,7 +44,7 @@ or plain strings.
 {{- if not (empty $pullSecrets) -}}
 imagePullSecrets:
   {{- range $pullSecrets | uniq }}
-  - name: {{ . }}
+  - name: {{ . | quote }}
   {{- end }}
 {{- end -}}
 {{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -25,3 +25,26 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 {{- define "linux-node-selector" -}}
 kubernetes.io/os: linux
 {{- end -}}
+
+{{/*
+Renders imagePullSecrets, accepting either object references ({ name: <secret> })
+or plain strings.
+*/}}
+{{- define "rancher-compliance.imagePullSecrets" -}}
+{{- $pullSecrets := list -}}
+{{- range .Values.global.cattle.imagePullSecrets -}}
+  {{- if kindIs "map" . -}}
+    {{- if .name -}}
+      {{- $pullSecrets = append $pullSecrets .name -}}
+    {{- end -}}
+  {{- else if not (empty .) -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- if not (empty $pullSecrets) -}}
+imagePullSecrets:
+  {{- range $pullSecrets | uniq }}
+  - name: {{ . }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
         compliance.cattle.io/operator: compliance-operator
     spec:
       serviceAccountName: compliance-operator-serviceaccount
+      {{- include "rancher-compliance.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: compliance-operator
         image: '{{ template "system_default_registry" . }}{{ .Values.image.operator.repository }}:{{ .Values.image.operator.tag }}'

--- a/chart/templates/patch_default_serviceaccount.yaml
+++ b/chart/templates/patch_default_serviceaccount.yaml
@@ -10,6 +10,7 @@ spec:
   template:
     spec:
       serviceAccountName: compliance-operator-serviceaccount
+      {{- include "rancher-compliance.imagePullSecrets" . | nindent 6 }}
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
 {{- if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -12,3 +12,4 @@ metadata:
     app.kubernetes.io/name: rancher-compliance
     app.kubernetes.io/instance: release-name
   name: compliance-scan-serviceaccount
+{{- include "rancher-compliance.imagePullSecrets" . | nindent 0 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -43,6 +43,8 @@ global:
   cattle:
     systemDefaultRegistry: ""
     clusterName: ""
+    # Optional pull secrets for private registries.
+    # Referenced secrets must exist in the chart release namespace (compliance-operator-system).
     imagePullSecrets: []
   kubectl:
     repository: rancher/kubectl

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,7 +5,7 @@
 image:
   operator:
     repository: rancher/compliance-operator
-    tag: v1.5.0-rc.3
+    tag: v1.5.0-rc.4
   securityScan:
     repository: rancher/security-scan
     tag: v0.10.0-rc.2
@@ -43,6 +43,7 @@ global:
   cattle:
     systemDefaultRegistry: ""
     clusterName: ""
+    imagePullSecrets: []
   kubectl:
     repository: rancher/kubectl
     tag: v1.36.0


### PR DESCRIPTION
issue : https://github.com/rancher/rancher/issues/54979
Add support for imagePullSecrets in the compliance-operator chart.

Changes
* Added a reusable imagePullSecrets helper template.
* Added imagePullSecrets support to the compliance-operator Deployment.
* Added imagePullSecrets support to the patch-sa Job.
* Added imagePullSecrets support to the compliance-scan-serviceaccount.
* Added global.cattle.imagePullSecrets to chart values.

Approach
The security scan jobs created by compliance-operator run using the compliance-scan-serviceaccount ServiceAccount (ClusterScanSA).Pods automatically inherit imagePullSecrets configured on their ServiceAccount.
Since the scan jobs already reference compliance-scan-serviceaccount, adding imagePullSecrets to the ServiceAccount allows dynamically created scan pods (security-scan and sonobuoy) to use imagePullSecrets without requiring changes to the operator’s Go code or Job PodSpec generation logic.