### PR TITLE
fix: renovate helm checksum update issue

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -19,9 +19,9 @@ KUBECTL_SUM_arm64 := 59f7ee8e477fae658447607dc3c8790ac17a1b016c01c622c12070e969e
 # renovate: datasource=github-releases packageName=kubernetes/kubernetes digestVersion=v1.36.1
 KUBECTL_SUM_amd64 := 629d3f410e09bf49b64ae7079f7f0bda1191efed311f7d37fdbab0ad5b0ec2b7
 
-# renovate: datasource=github-release-attachments depName=helm/helm
+# renovate-local: helm-amd64
 HELM_VERSION = v4.2.0
-# renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v4.2.0
-HELM_SUM_amd64 := 97dbeb971be4ac4b27e3839976d9564c0fb35c6f3b1da89dd1e292d236af4096
-# renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v4.2.0
-HELM_SUM_arm64 := 1f8de130dfbd04de64978e7b852a7a547be1404956a366608276d2520b678670
+# renovate-local: helm-amd64=v4.2.0
+HELM_CHECKSUM_amd64 := 97dbeb971be4ac4b27e3839976d9564c0fb35c6f3b1da89dd1e292d236af4096
+# renovate-local: helm-arm64=v4.2.0
+HELM_CHECKSUM_arm64 := 1f8de130dfbd04de64978e7b852a7a547be1404956a366608276d2520b678670

--- a/hack/make/tools.mk
+++ b/hack/make/tools.mk
@@ -43,7 +43,7 @@ $(HELM):
 	mkdir -p $(TOOLS_BIN)/tmp-helm
 	curl -sSfL -o $(TOOLS_BIN)/helm.tar.gz \
 		"https://get.helm.sh/helm-$(HELM_VERSION)-$(OS_NAME)-$(OS_ARCH).tar.gz"
-	echo "$(HELM_SUM_$(OS_ARCH))  $(TOOLS_BIN)/helm.tar.gz" | shasum -a 256 -c -
+	echo "$(HELM_CHECKSUM_$(OS_ARCH))  $(TOOLS_BIN)/helm.tar.gz" | shasum -a 256 -c -
 	tar -xf $(TOOLS_BIN)/helm.tar.gz --strip-components 1 -C $(TOOLS_BIN)/tmp-helm
 	mv $(TOOLS_BIN)/tmp-helm/helm $(HELM)
 	chmod u+x $(HELM)


### PR DESCRIPTION
This PR updates the Helm checksum variable names to align with the naming convention used by Rancher's shared [Renovate](https://github.com/rancher/renovate-config) configuration. The goal is to align this repository with Rancher's custom Helm update mechanism, which manages Helm versions and checksums using regex managers and checksum metadata generated from get.helm.sh instead of relying on the default github-release-attachments datasource.
Changes
Renamed HELM_SUM_amd64 to HELM_CHECKSUM_amd64.
Renamed HELM_SUM_arm64 to HELM_CHECKSUM_arm64.
Updated hack/make/tools.mk to reference the renamed checksum variables.
Updated the inline Renovate annotations for Helm to align with Rancher's shared Renovate configuration.